### PR TITLE
Fix mention to ido in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -47,7 +47,7 @@
     cider
 
     ;; allow ido usage in as many contexts as possible. see
-    ;; customizations/better-defaults.el line 47 for a description
+    ;; customizations/navigation.el line 23 for a description
     ;; of ido
     ido-ubiquitous
 


### PR DESCRIPTION
Not using Emacs (yet ?), but spotted a small mistake. I suppose it was right some ago, but not anymore since better-defaults.el doesn't even exist.