### PR TITLE
Make disabling the menu bar platform dependent.

### DIFF
--- a/customizations/ui.el
+++ b/customizations/ui.el
@@ -4,8 +4,10 @@
 ;; a matter of preference and may require some fiddling to match your
 ;; preferences
 
-;; Turn off the menu bar at the top of each frame because it's distracting
-(menu-bar-mode -1)
+;; Turn off the menu bar at the top of each frame because it's distracting,
+;; unless it's on Mac where the single menu bar is always present but with
+;; -1 will not include the mode-specific menu entries.
+(if (not (eq system-type 'darwin)) (menu-bar-mode -1))
 
 ;; Show line numbers
 (global-linum-mode)


### PR DESCRIPTION
When disabling the menu bar, on OS X there's still the (single)
menu bar, but it will only have the default entries, not the ones
installed by each major mode. Only disable the menu bar when not on
'darwin.

This is a reopen of https://github.com/flyingmachine/emacs-for-clojure/pull/16, which I'm closing because I opened it on master by mistake and want to push changes to my master for my own needs.