### PR TITLE
using setq to set my-packages

### DIFF
--- a/init.el
+++ b/init.el
@@ -30,7 +30,8 @@
 ;; The packages you want installed. You can also install these
 ;; manually with M-x package-install
 ;; Add in your own as you wish:
-(defvar my-packages
+(defvar my-packages nil)
+(setq my-packages
   '(;; makes handling lisp expressions much, much easier
     ;; Cheatsheet: http://www.emacswiki.org/emacs/PareditCheatsheet
     paredit


### PR DESCRIPTION
If you add new packages to the my-packages list, eval'ing the file will not download the newly added package. Using `setq` instead of `defvar` should fix the [issue](http://ergoemacs.org/emacs/elisp_defvar_problem.html). 

Adding this change worked for me. I can now run `M-x load-file` and see my new packages. 