### PR TITLE
Update init.el to avoid reference warnings

### DIFF
--- a/init.el
+++ b/init.el
@@ -27,6 +27,14 @@
 (when (not package-archive-contents)
   (package-refresh-contents))
 
+;; Define he following variables to remove the compile-log warnings
+;; when defining ido-ubiquitous
+(defvar ido-cur-item nil)
+(defvar ido-default-item nil)
+(defvar ido-cur-list nil)
+(defvar predicate nil)
+(defvar inherit-input-method nil)
+
 ;; The packages you want installed. You can also install these
 ;; manually with M-x package-install
 ;; Add in your own as you wish:


### PR DESCRIPTION
When starting up Emacs (OSX), reference warnings are always shown in the compile-log window. It seems to happen as well on Windows (https://github.com/flyingmachine/emacs-for-clojure/issues/26).

It seems like binding the said references to nil fixes the problem as stated from https://github.com/DarwinAwardWinner/ido-ubiquitous/issues/35
