### PR TITLE
eldoc-mode

### DIFF
--- a/customizations/setup-clojure.el
+++ b/customizations/setup-clojure.el
@@ -30,7 +30,7 @@
 ;;;;
 
 ;; provides minibuffer documentation for the code you're typing into the repl
-(add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
+(add-hook 'cider-mode-hook 'eldoc-mode)
 
 ;; go right to the REPL buffer when it's finished connecting
 (setq cider-repl-pop-to-buffer-on-connect t)


### PR DESCRIPTION
currently, cider directly uses `eldoc-mode`. Cheers