### PR TITLE
Removing marmalade

### DIFF
--- a/init.el
+++ b/init.el
@@ -5,14 +5,11 @@
 ;; Define package repositories
 (require 'package)
 (add-to-list 'package-archives
-             '("marmalade" . "http://marmalade-repo.org/packages/") t)
-(add-to-list 'package-archives
              '("tromey" . "http://tromey.com/elpa/") t)
 (add-to-list 'package-archives
              '("melpa" . "http://melpa.milkbox.net/packages/") t)
 
 ;; (setq package-archives '(("gnu" . "http://elpa.gnu.org/packages/")
-;;                          ("marmalade" . "http://marmalade-repo.org/packages/")
 ;;                          ("melpa" . "http://melpa-stable.milkbox.net/packages/")))
 
 


### PR DESCRIPTION
removing marmalade, tls has been broken since October 2016: https://goo.gl/RxE1aE. This exposes noobs to unnecessary security risks and confusion.