### PR TITLE
global-rainbow-delimiters-mode was deprecated

### DIFF
--- a/customizations/editing.el
+++ b/customizations/editing.el
@@ -51,9 +51,6 @@
   (comment-or-uncomment-region (line-beginning-position) (line-end-position)))
 (global-set-key (kbd "C-;") 'toggle-comment-on-line)
 
-;; yay rainbows!
-(global-rainbow-delimiters-mode t)
-
 ;; use 2 spaces for tabs
 (defun die-tabs ()
   (interactive)

--- a/customizations/elisp-editing.el
+++ b/customizations/elisp-editing.el
@@ -13,3 +13,6 @@
 (add-hook 'emacs-lisp-mode-hook 'turn-on-eldoc-mode)
 (add-hook 'lisp-interaction-mode-hook 'turn-on-eldoc-mode)
 (add-hook 'ielm-mode-hook 'turn-on-eldoc-mode)
+
+;; Load rainbow mode in most programming modes (Emacs 24 and above)
+(add-hook 'prog-mode-hook #'rainbow-delimiters-mode)


### PR DESCRIPTION
From [rainbow-delimiters repo](https://github.com/Fanael/rainbow-delimiters#global-mode) :

> There's no **global-rainbow-delimiters-mode** anymore. It used to exist, but it was impossible to keep it from breaking some major modes. It's strongly recommended to use major mode hooks instead, as shown above. There's nothing stopping you from defining global-rainbow-delimiters-mode yourself, but if it breaks something, you're on your own.

