### PR TITLE
fix: remove deprecated package archives

### DIFF
--- a/init.el
+++ b/init.el
@@ -5,9 +5,7 @@
 ;; Define package repositories
 (require 'package)
 (add-to-list 'package-archives
-             '("tromey" . "http://tromey.com/elpa/") t)
-(add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "http://melpa.org/packages/") t)
 (add-to-list 'package-archives
              '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 


### PR DESCRIPTION
This PR changes the package archives to `melpa` and `melpa stable`. I am an Emacs beginner and learning about how to configure it. As I understand it the `tromey` and `milkbox` archives are deprecated (I also got warnings about failed installations in Emacs at first run).