### PR TITLE
fix: enable special chars in editor

### DIFF
--- a/customizations/editing.el
+++ b/customizations/editing.el
@@ -67,3 +67,6 @@
     (quit nil)))
 
 (setq electric-indent-mode nil)
+
+;; enable special chars in the editor, like ~ and ^.
+(load-library "iso-transl")


### PR DESCRIPTION
This PR will enable special characters like `~` and `^` in the editor, useful for when writing shorthand subscriptions syntacs in `clojurescript` with `re-frame`.