### PR TITLE
fix: enable clojurescript mode for cljs files

### DIFF
--- a/customizations/setup-clojure.el
+++ b/customizations/setup-clojure.el
@@ -52,7 +52,7 @@
 ;; Use clojure mode for other extensions
 (add-to-list 'auto-mode-alist '("\\.edn$" . clojure-mode))
 (add-to-list 'auto-mode-alist '("\\.boot$" . clojure-mode))
-(add-to-list 'auto-mode-alist '("\\.cljs.*$" . clojure-mode))
+(add-to-list 'auto-mode-alist '("\\.cljs.*$" . clojurescript-mode))
 (add-to-list 'auto-mode-alist '("lein-env" . enh-ruby-mode))
 
 


### PR DESCRIPTION
This PR will enable `clojurescript-mode` for buffers with the file extension `cljs`.

Otherwise, Emacs will warn about using `clojure-mode` for clojurescript buffers.