### PR TITLE
update init.el with the new melpa archive url

### DIFF
--- a/init.el
+++ b/init.el
@@ -7,7 +7,7 @@
 (add-to-list 'package-archives
              '("tromey" . "http://tromey.com/elpa/") t)
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "http://melpa.org/packages/") t)
 (add-to-list 'package-archives
              '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 


### PR DESCRIPTION
This PR fixes 'Failed to download melpa' when running package-refresh-contents.